### PR TITLE
fix: comparing utc to relative tz was off

### DIFF
--- a/pinthesky/session.py
+++ b/pinthesky/session.py
@@ -38,8 +38,8 @@ class Session(Handler):
         self.credentials_endpoint = endpoint
 
     def __is_expired(self, current_time):
-        expiration = self.credentials['expiration']
-        expiry = datetime.datetime.strptime(expiration, "%Y-%m-%dT%H:%M:%SZ")
+        expiration = self.credentials['expiration'].replace('Z', ' UTC')
+        expiry = datetime.datetime.strptime(expiration, "%Y-%m-%dT%H:%M:%S %Z")
         return expiry < current_time
 
     def on_file_change(self, event):
@@ -56,7 +56,7 @@ class Session(Handler):
                             setattr(self, field, con[field])
 
     def login(self, force=False):
-        ct = datetime.datetime.now()
+        ct = datetime.datetime.utcnow()
         if force or self.credentials is None or self.__is_expired(ct):
             with self.refresh_lock:
                 try:


### PR DESCRIPTION
- Fixes and issue with the caching mechanism

```
Jul 22 19:59:20 raspberrypi pinthesky[29690]: botocore.exceptions.ClientError: An error occurred (ExpiredToken) when calling the PutObject operation: The provided token has expired.
Jul 22 19:59:20 raspberrypi pinthesky[29690]:     raise error_class(parsed_response, operation_name)
Jul 22 19:59:20 raspberrypi pinthesky[29690]:   File "/usr/local/lib/python3.9/dist-packages/botocore/client.py", line 915, in _make_api_call
Jul 22 19:59:20 raspberrypi pinthesky[29690]:     return self._make_api_call(operation_name, kwargs)
Jul 22 19:59:20 raspberrypi pinthesky[29690]:   File "/usr/local/lib/python3.9/dist-packages/botocore/client.py", line 508, in _api_call
Jul 22 19:59:20 raspberrypi pinthesky[29690]:     client.put_object(Bucket=bucket, Key=key, Body=body, **extra_args)
Jul 22 19:59:20 raspberrypi pinthesky[29690]:   File "/usr/local/lib/python3.9/dist-packages/s3transfer/upload.py", line 758, in _main
Jul 22 19:59:20 raspberrypi pinthesky[29690]:     return_value = self._main(**kwargs)
Jul 22 19:59:20 raspberrypi pinthesky[29690]:   File "/usr/local/lib/python3.9/dist-packages/s3transfer/tasks.py", line 162, in _execute_main
Jul 22 19:59:20 raspberrypi pinthesky[29690]:     return self._execute_main(kwargs)
Jul 22 19:59:20 raspberrypi pinthesky[29690]:   File "/usr/local/lib/python3.9/dist-packages/s3transfer/tasks.py", line 139, in __call__
Jul 22 19:59:20 raspberrypi pinthesky[29690]:     raise self._exception
Jul 22 19:59:20 raspberrypi pinthesky[29690]:   File "/usr/local/lib/python3.9/dist-packages/s3transfer/futures.py", line 266, in result
Jul 22 19:59:20 raspberrypi pinthesky[29690]:     return self._coordinator.result()
Jul 22 19:59:20 raspberrypi pinthesky[29690]:   File "/usr/local/lib/python3.9/dist-packages/s3transfer/futures.py", line 103, in result
Jul 22 19:59:20 raspberrypi pinthesky[29690]:     return future.result()
Jul 22 19:59:20 raspberrypi pinthesky[29690]:   File "/usr/local/lib/python3.9/dist-packages/boto3/s3/inject.py", line 636, in upload_fileobj
Jul 22 19:59:20 raspberrypi pinthesky[29690]:     s3.upload_fileobj(f, self.bucket_name, loc)
Jul 22 19:59:20 raspberrypi pinthesky[29690]:   File "/usr/local/lib/python3.9/dist-packages/pinthesky/upload.py", line 41, in __upload_to_bucket
Jul 22 19:59:20 raspberrypi pinthesky[29690]:     self.__upload_to_bucket(
Jul 22 19:59:20 raspberrypi pinthesky[29690]:   File "/usr/local/lib/python3.9/dist-packages/pinthesky/upload.py", line 59, in on_capture_image_end
Jul 22 19:59:20 raspberrypi pinthesky[29690]:     handler(message)
Jul 22 19:59:20 raspberrypi pinthesky[29690]:   File "/usr/local/lib/python3.9/dist-packages/pinthesky/events.py", line 58, in run
```