### PR TITLE
fix: config input reset

### DIFF
--- a/pinthesky/__main__.py
+++ b/pinthesky/__main__.py
@@ -188,6 +188,7 @@ def main():
         events=event_thread,
         configure_input=parsed.configure_input,
         configure_output=parsed.configure_output)
+    event_thread.on(shadow_update)
     shadow_update.add_handler(camera_thread)
     shadow_update.add_handler(auth_session)
     if not shadow_update.update_document(parsed):

--- a/pinthesky/camera.py
+++ b/pinthesky/camera.py
@@ -182,7 +182,6 @@ class CameraThread(threading.Thread, Handler, ShadowConfigHandler):
     def pause(self):
         if self.camera.recording:
             self.camera.stop_recording()
-            self.historical_stream.clear()
             logger.info("Camera recording is now paused")
             return True
         return False

--- a/pinthesky/camera.py
+++ b/pinthesky/camera.py
@@ -153,6 +153,7 @@ class CameraThread(threading.Thread, Handler, ShadowConfigHandler):
             self.camera.split_recording(f'{self.flushing_ts}.after.h264')
             self.historical_stream.copy_to(f'{self.flushing_ts}.before.h264')
             self.historical_stream.clear()
+            logger.info("Flushed buffered contents")
             time.sleep(self.buffer)
             self.camera.split_recording(self.historical_stream)
             self.events.fire_event('flush_end', {
@@ -181,6 +182,7 @@ class CameraThread(threading.Thread, Handler, ShadowConfigHandler):
     def pause(self):
         if self.camera.recording:
             self.camera.stop_recording()
+            self.historical_stream.clear()
             logger.info("Camera recording is now paused")
             return True
         return False

--- a/pinthesky/config.py
+++ b/pinthesky/config.py
@@ -3,6 +3,8 @@ import json
 import logging
 import os
 
+from pinthesky.handler import Handler
+
 
 logger = logging.getLogger(__name__)
 
@@ -20,7 +22,7 @@ class ShadowConfigHandler:
         pass
 
 
-class ShadowConfig:
+class ShadowConfig(Handler):
     def __init__(
             self,
             events,
@@ -74,3 +76,11 @@ class ShadowConfig:
             logger.info(f'Successfully updated {self.__configure_input}')
             return True
         return False
+
+    def on_file_change(self, event):
+        if event['file_name'] == self.__configure_output:
+            if os.path.getsize(self.__configure_input) > 0:
+                logger.info(f'Truncating {self.__configure_input}')
+                # TODO: probably want to lock on it
+                with open(self.__configure_input, 'w') as f:
+                    f.write("")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -106,3 +106,38 @@ def test_shadow_reset():
     os.remove(configure_output)
     assert test_handler.calls['file_change'] == 1
     events.stop()
+
+
+def test_shadow_config_reset():
+    events = EventThread()
+    configure_input = "test_shadow_input.json"
+    configure_output = "test_shadow_output.json"
+    shadow_config = ShadowConfig(
+        events=events,
+        configure_input=configure_input,
+        configure_output=configure_output)
+    events.on(shadow_config)
+    with open(configure_input, 'w') as f:
+        f.write(json.dumps({
+            'some': 'key',
+            'other': 'value'
+        }))
+    with open(configure_output, 'w') as f:
+        f.write(json.dumps({
+            'some': 'new_key',
+            'other': 'new_value'
+        }))
+    events.start()
+    events.fire_event('file_change', {
+        'file_name': configure_output,
+        'context': {
+        }
+    })
+    while not events.event_queue.empty():
+        pass
+    with open(configure_input, 'r') as f:
+        content = f.read()
+    os.remove(configure_input)
+    os.remove(configure_output)
+    assert content == ""
+    events.stop()


### PR DESCRIPTION
- Whenever the AWS IoT device client reads the input, it does not truncate the file
- When the device client reboots, it resets the config
- Now the config handler will truncate it's own input if the output is refreshed.