### PR TITLE
fix: buffer in size not in temporal

### DIFF
--- a/pinthesky/__main__.py
+++ b/pinthesky/__main__.py
@@ -57,6 +57,11 @@ def create_parser():
         type=int,
         default=15)
     parser.add_argument(
+        "--buffer-size",
+        help="buffer size in bytes, unset by default and uses buffer",
+        type=int,
+        default=None)
+    parser.add_argument(
         "--sensitivity",
         help="sensitivity of the motion detection math, default 10",
         type=int,
@@ -185,7 +190,8 @@ def main():
         encoding_level=parsed.encoding_level,
         encoding_profile=parsed.encoding_profile,
         recording_window=parsed.recording_window,
-        capture_dir=parsed.capture_dir)
+        capture_dir=parsed.capture_dir,
+        buffer_size=parsed.buffer_size)
     video_combiner = VideoCombiner(
         events=event_thread,
         combine_dir=parsed.combine_dir)

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -18,6 +18,7 @@ def test_configuration_change():
         resolution=(640, 480),
         framerate=20,
         rotation=270,
+        buffer_size=1000000,
         buffer=15,
         recording_window="0-23")
     events.on(camera)
@@ -29,6 +30,7 @@ def test_configuration_change():
                     'desired': {
                         'camera': {
                             'buffer': '20',
+                            'buffer_size': '2000000',
                             'sensitivity': '20',
                             'recording_window': '12-20',
                             'rotation': '180',
@@ -49,6 +51,7 @@ def test_configuration_change():
     assert camera.buffer == 20
     assert camera.sensitivity == 20
     assert camera.encoding_bitrate == 5000000
+    assert camera.buffer_size == 2000000
     assert camera.encoding_level == '2.1'
     assert camera.encoding_profile == 'main'
     assert camera.camera.framerate == 30
@@ -76,6 +79,7 @@ def test_configuration_update():
         recording_window="0-23")
     assert camera.update_document() == ConfigUpdate('camera', {
         'buffer': 15,
+        'buffer_size': None,
         'sensitivity': 10,
         'rotation': 270,
         'resolution': '640x480',

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -35,4 +35,6 @@ def test_input_reader():
         assert client_handler.calls['motion_start'] == 5
         assert client_handler.calls['file_change'] == 5
     finally:
+        notify.stop()
+        events.stop()
         os.remove(test_file)


### PR DESCRIPTION
- Fixes #32 
- Adds a new `--buffer-size` parameter and support from config to cut the circular buffer in size not in length