### PR TITLE
chore: logging and event handling

### DIFF
--- a/pinthesky/events.py
+++ b/pinthesky/events.py
@@ -50,7 +50,7 @@ class EventThread(threading.Thread):
             'timestamp': floor(time.time())
         }
         if event_name in self.handlers:
-            logger.info(f'Pushing {event_data["name"]} to event queue')
+            logger.debug(f'Pushing {event_data["name"]} to event queue')
             self.event_queue.put(dict(context, **event_data))
 
     def run(self):

--- a/pinthesky/health.py
+++ b/pinthesky/health.py
@@ -113,7 +113,7 @@ class DeviceHealth(Handler, ShadowConfigHandler):
             context = dict(context, **metric.report())
         self.events.fire_event('health_end', context)
         self.last_flush_time = datetime.utcnow()
-        logger.info('Emitted health metric data')
+        logger.debug('Emitted health metric data')
         return context
 
     def emit_health(self, force=False):

--- a/pinthesky/output.py
+++ b/pinthesky/output.py
@@ -18,7 +18,7 @@ class Output(Handler):
         self.write_lock = Lock()
 
     def __on_event(self, event):
-        logger.info(f'Flushing {event["name"]} to {self.output_file}')
+        logger.debug(f'Flushing {event["name"]} to {self.output_file}')
         # Augment the thing name in outbound messages
         if self.thing_name is not None:
             event["thing_name"] = self.thing_name
@@ -26,16 +26,7 @@ class Output(Handler):
             with open(self.output_file, 'w') as f:
                 f.write(json.dumps(event))
 
-    def on_motion_start(self, event):
-        self.__on_event(event)
-
-    def on_combine_end(self, event):
-        self.__on_event(event)
-
     def on_upload_end(self, event):
-        self.__on_event(event)
-
-    def on_capture_image_end(self, event):
         self.__on_event(event)
 
     def on_health_end(self, event):

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -25,7 +25,7 @@ def test_output():
         })
         time.sleep(0.01)
     try:
-        assert client.calls['file_change'] == 6
+        assert client.calls['file_change'] == 3
         output.reset()
         with open(test_output, 'r') as f:
             assert f.read() == ""

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -6,10 +6,12 @@ from unittest.mock import patch
 from pinthesky.upload import S3Upload
 from pinthesky.events import EventThread
 from pinthesky.session import Session
+from tests.test_handler import TestHandler
 
 
 @patch('boto3.Session')
 def test_upload(bsession):
+    test_handler = TestHandler()
     events = EventThread()
     session = Session(
         cert_path="cert_path",
@@ -33,18 +35,69 @@ def test_upload(bsession):
     }
     events.on(session)
     events.on(upload)
+    events.on(test_handler)
     events.start()
-    video_file = 'test_video.h264'
-    with open(video_file, 'w') as f:
+    tuple = [
+        ('combine_end', 'combine_video'),
+        ('capture_image_end', 'image_file')
+    ]
+    for event_name, field in tuple:
+        data_file = f'{field}.data'
+        with open(data_file, 'w') as f:
+            f.write("hello")
+        context = {'start_time': floor(time())}
+        context[field] = data_file
+        events.fire_event(event_name, context)
+    while events.event_queue.unfinished_tasks > 0:
+        pass
+    try:
+        assert bsession.called
+        # Called once because image prefix is unset
+        assert test_handler.calls['upload_end'] == 1
+    finally:
+        for event_name, field in tuple:
+            if os.path.exists(f'{field}.data'):
+                os.remove(f'{field}.data')
+
+
+@patch('boto3.Session')
+def test_upload(bsession):
+    events = EventThread()
+    session = Session(
+        cert_path="cert_path",
+        key_path="key_path",
+        cacert_path="cacert_path",
+        thing_name="thing_name",
+        role_alias="role_alias",
+        credentials_endpoint="example.com")
+    upload = S3Upload(
+        events=events,
+        bucket_name="bucket_name",
+        bucket_prefix="motion-videos",
+        bucket_image_prefix="capture_images",
+        session=session)
+    now = datetime.now()
+    next_year = datetime(year=now.year + 1, month=now.month, day=1)
+    session.credentials = {
+        'accessKeyId': 'abc',
+        'secretAccessKey': 'efg',
+        'sessionToken': '123',
+        'expiration': next_year.strftime("%Y-%m-%dT%H:%M:%SZ")
+    }
+    events.on(session)
+    events.on(upload)
+    events.start()
+    image_file = 'test_image.jpg'
+    with open(image_file, 'w') as f:
         f.write("hello")
-    events.fire_event('combine_end', {
+    events.fire_event('capture_image_end', {
         'start_time': floor(time()),
-        'combine_video': video_file
+        'image_file': image_file
     })
     while events.event_queue.unfinished_tasks > 0:
         pass
     try:
         assert bsession.called
     finally:
-        if os.path.exists(video_file):
-            os.remove(video_file)
+        if os.path.exists(image_file):
+            os.remove(image_file)

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -61,7 +61,7 @@ def test_upload(bsession):
 
 
 @patch('boto3.Session')
-def test_upload(bsession):
+def test_image_upload(bsession):
     events = EventThread()
     session = Session(
         cert_path="cert_path",


### PR DESCRIPTION
- Downgrading some `INFO` to `DEBUG` since it's chatty in the `journalctl`
- Removing some watched events that go to MQTT output. Normally this change would require a major version bump, sine it would be consider backwards incompatible. That said, since runtime outbound never worked prior to `0.5.0` this is a safe removal. Now the events sourced from the device are `health` updates and `upload`.