### PR TITLE
feat: force video capture through command

### DIFF
--- a/pinthesky/combiner.py
+++ b/pinthesky/combiner.py
@@ -29,11 +29,14 @@ class VideoCombiner(Handler):
         with open(file_name, 'wb') as o:
             for n in ['before', 'after']:
                 part_name = f'{event["start_time"]}.{n}.h264'
+                if not os.path.exists(part_name):
+                    continue
                 with open(part_name, 'rb') as i:
                     o.write(i.read())
                 os.remove(part_name)
         self.events.fire_event('combine_end', {
             'start_time': event['start_time'],
-            'combine_video': file_name
+            'combine_video': file_name,
+            'trigger': event['trigger'],
         })
         logger.info(f'Finish concatinating to {file_name}')

--- a/pinthesky/combiner.py
+++ b/pinthesky/combiner.py
@@ -29,8 +29,6 @@ class VideoCombiner(Handler):
         with open(file_name, 'wb') as o:
             for n in ['before', 'after']:
                 part_name = f'{event["start_time"]}.{n}.h264'
-                if not os.path.exists(part_name):
-                    continue
                 with open(part_name, 'rb') as i:
                     o.write(i.read())
                 os.remove(part_name)

--- a/pinthesky/events.py
+++ b/pinthesky/events.py
@@ -16,6 +16,7 @@ event_names = [
     'file_change',
     'capture_image',
     'capture_image_end',
+    'capture_video',
     'recording_change',
     'health',
     'health_end'

--- a/pinthesky/handler.py
+++ b/pinthesky/handler.py
@@ -38,6 +38,13 @@ class Handler():
         """
         pass
 
+    def on_capture_video(self, event):
+        """
+        Handle the event signaling the user's intent to capture a video feed.
+        Event fields are `duration` (optional... will use buffer)
+        """
+        pass
+
     def on_capture_image(self, event):
         """
         Handle the call capture event image.

--- a/pinthesky/upload.py
+++ b/pinthesky/upload.py
@@ -25,7 +25,7 @@ class S3Upload(Handler):
         self.session = session
         self.bucket_image_prefix = bucket_image_prefix
 
-    def __upload_to_bucket(self, prefix, file_obj, source):
+    def __upload_to_bucket(self, prefix, file_obj, source, extra_args=None):
         creds = self.session.login()
         if self.bucket_name is not None and creds is not None:
             video = os.path.basename(file_obj)
@@ -38,7 +38,7 @@ class S3Upload(Handler):
             try:
                 s3 = session.client('s3')
                 with open(file_obj, 'rb') as f:
-                    s3.upload_fileobj(f, self.bucket_name, loc)
+                    s3.upload_fileobj(f, self.bucket_name, loc, ExtraArgs=extra_args)
                     logger.info(f'Uploaded to s3://{self.bucket_name}/{loc}')
                 self.events.fire_event('upload_end', {
                     'start_time': source['start_time'],
@@ -66,4 +66,9 @@ class S3Upload(Handler):
         self.__upload_to_bucket(
             self.bucket_prefix,
             event['combine_video'],
-            event)
+            event,
+            extra_args={
+                'Metadata': {
+                    'trigger': event['trigger']
+                }
+            })

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -128,6 +128,7 @@ def test_camera_run():
     finally:
         camera.stop()
 
+
 def test_camera_capture_video():
     pinthesky.set_stream_logger()
     camera_class = mock.MagicMock()

--- a/tests/test_combiner.py
+++ b/tests/test_combiner.py
@@ -20,7 +20,8 @@ def test_combiner():
     with open(f'{start_time}.after.h264', 'w') as f:
         f.write("World!")
     events.fire_event("flush_end", {
-        'start_time': start_time
+        'start_time': start_time,
+        'trigger': 'motion',
     })
     while not hasattr(handler, 'calls') or "combine_end" not in handler.calls:
         pass

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -40,6 +40,9 @@ class TestHandler(Handler):
     def on_health_end(self, event):
         self.__on_event('health_end', event)
 
+    def on_capture_video(self, event):
+        self.__on_event('capture_video', event)
+
 
 def test_handler():
     handler = TestHandler()

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -45,7 +45,7 @@ def test_upload(bsession):
         data_file = f'{field}.data'
         with open(data_file, 'w') as f:
             f.write("hello")
-        context = {'start_time': floor(time())}
+        context = {'start_time': floor(time()), 'trigger': 'motion'}
         context[field] = data_file
         events.fire_event(event_name, context)
     while events.event_queue.unfinished_tasks > 0:


### PR DESCRIPTION
- Adds a new event called `capture_video` which informs the camera to record and flush buffers manually
- Adds the ability for the s3 uploader to tag metadata on the video which will surface on the portal