### PR TITLE
fix: cli param parsing

### DIFF
--- a/pinthesky/__main__.py
+++ b/pinthesky/__main__.py
@@ -241,7 +241,7 @@ def main():
         delineate_stream=not parsed.disable_cloudwatch_stream_split,
         threaded=parsed.cloudwatch_thread,
         enabled=parsed.cloudwatch,
-        log_group_name=parsed.cloudwatch_log_stream,
+        log_group_name=parsed.cloudwatch_log_group,
         namespace=parsed.cloudwatch_metric_namespace,
         event_type=parsed.cloudwatch_event_type)
     event_thread.on(camera_thread)


### PR DESCRIPTION
- fixing the parsing for CLI's

```
Apr 04 17:44:26 raspberrypi systemd[1]: pinthesky.service: Consumed 5.669s CPU time.                                                                                                                               
Apr 04 17:44:26 raspberrypi systemd[1]: pinthesky.service: Failed with result 'exit-code'.                                                                                                                         
Apr 04 17:44:26 raspberrypi systemd[1]: pinthesky.service: Main process exited, code=exited, status=1/FAILURE                                                                                                      
Apr 04 17:44:25 raspberrypi pinthesky[11612]: AttributeError: 'Namespace' object has no attribute 'cloudwatch_log_stream'                                                                                          
Apr 04 17:44:25 raspberrypi pinthesky[11612]:     log_group_name=parsed.cloudwatch_log_stream,                                                                                                                     
Apr 04 17:44:25 raspberrypi pinthesky[11612]:   File "/usr/local/lib/python3.9/dist-packages/pinthesky/__main__.py", line 244, in main                                                                             
Apr 04 17:44:25 raspberrypi pinthesky[11612]:     sys.exit(main())                                                                                                                                                 
Apr 04 17:44:25 raspberrypi pinthesky[11612]:   File "/usr/local/bin/pinthesky", line 8, in <module>                                                                                                               
Apr 04 17:44:25 raspberrypi pinthesky[11612]: Traceback (most recent call last):    
```