### PR TITLE
feat: jsmpeg magic header for browser streaming

### DIFF
--- a/pinthesky/camera.py
+++ b/pinthesky/camera.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from pinthesky.config import ConfigUpdate, ShadowConfigHandler
 from pinthesky.handler import Handler
 from pinthesky.health import DeviceHealth
-from pinthesky.conversion import VideoConversion
+from pinthesky.conversion import VideoConversion, JSMPEGHeader
 from pinthesky.connection import ProcessBuffer, ConnectionThread
 import logging
 import time
@@ -264,6 +264,9 @@ class CameraThread(threading.Thread, Handler, ShadowConfigHandler):
 
     def record(self, event):
         if not self.camera.recording:
+            # Recording event was initated with a valid session connection
+            # Pump the magic header into the connection for streaming
+            JSMPEGHeader(self.connection_manager, event, self.camera).send()
             conversion = VideoConversion(self.camera)
             self.recording_thread = ConnectionThread(
                 buffer=ProcessBuffer(conversion.process),

--- a/pinthesky/connection.py
+++ b/pinthesky/connection.py
@@ -12,6 +12,21 @@ FRAME_SIZE = 32768
 logger = logging.getLogger(__name__)
 
 
+class ProtocolData():
+    def __init__(self, manager, event_data) -> None:
+        self.manager = manager
+        self.event_data = event_data
+
+    def protocol(self):
+        pass
+
+    def send(self):
+        return self.manager.post_to_connection(
+            connection_id=self.event_data['connection']['id'],
+            data=self.protocol(),
+        )
+
+
 class ConnectionBuffer():
     def close(self):
         pass

--- a/pinthesky/conversion.py
+++ b/pinthesky/conversion.py
@@ -1,6 +1,22 @@
 import io
 import os
 from subprocess import Popen, PIPE
+from pinthesky.connection import ProtocolData
+from struct import Struct
+
+
+JSMPEG_MAGIC = b'jsmp'
+JSMPEG_HEADER = Struct('>4sHH')
+
+
+class JSMPEGHeader(ProtocolData):
+    def __init__(self, manager, event_data, camera) -> None:
+        super().__init__(manager, event_data)
+        self.camera = camera
+
+    def protocol(self):
+        (width, height) = self.camera.resolution
+        return JSMPEG_HEADER.pack(JSMPEG_MAGIC, width, height)
 
 
 class VideoConversion():

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -2,7 +2,7 @@ import boto3
 import json
 from botocore.exceptions import ClientError
 from functools import partial
-from pinthesky.connection import ConnectionThread, ConnectionHandler, ConnectionManager, ProcessBuffer
+from pinthesky.connection import ConnectionThread, ConnectionHandler, ConnectionManager, ProcessBuffer, ProtocolData
 from pinthesky.config import ConfigUpdate
 from pinthesky.events import EventThread
 from unittest.mock import patch, MagicMock
@@ -249,3 +249,24 @@ def test_connection_handler():
                 'manager_id': '$managerId',
             }
         })
+
+
+def test_protocol_data():
+    manager = MagicMock()
+    data = ProtocolData(
+        manager=manager,
+        event_data={
+            'connection': {
+                'id': 'test',
+            }
+        }
+    )
+
+    def post_to_connection(connection_id, data):
+        assert connection_id == 'test'
+        assert data is None
+        return True
+
+    manager.post_to_connection = post_to_connection
+
+    assert data.send()


### PR DESCRIPTION
- Adding `ProtocolData` command for sending special protocols